### PR TITLE
Clarify character vector handling & tidy up

### DIFF
--- a/R/clipboard.R
+++ b/R/clipboard.R
@@ -1,46 +1,53 @@
 #' Read clipboard
 #'
-#' Read the contents of the system clipboard into a character vector
+#' Read the contents of the system clipboard into a character vector.
 #'
 #' @return A character vector with the contents of the clipboard.
 #'
 #' @export
 read_clip <- function() {
   # Determine system type
-  stype <- sys_type()
+  sys.type <- sys_type()
 
-  # Pass to appropriate handler function
-  if(stype == "Darwin") {
-    osx_read_clip()
-  } else if(stype == "Windows") {
-    win_read_clip()
-  } else if(stype == "Linux") {
-    linux_read_clip()
-  } else {
-    stop("System not recognized!")
-  }
+  # Use the appropriate handler function
+  switch(sys.type,
+        "Darwin" = osx_read_clip(),
+        "Linux" = linux_read_clip(),
+        "Windows" = win_read_clip(),
+        stop("System not recognized!")
+  )
 }
 
 #' Write clipboard
 #'
 #' Write a character vector to the system clipboard
 #'
-#' @param content A character vector to be written to the system clipboard
+#' @param content A character vector to be written to the system clipboard.
+#'                Anything not a character vector will be coerced to one.
+#' @param sep A character vector (string) to join each element in content using.
+#'            Defaults to the operating system's newline character, indicated by \code{NULL}.
+#' @param eos The terminator to be written after each string, followed by an ASCII \code{nul}.
+#'            Defaults to no terminator character, indicated by \code{NULL}.
 #' @return On successfully writing the input to the clipboard, this function
 #'   returns the same input for use in piped operations.
 #' @export
-write_clip <- function(content) {
+write_clip <- function(content, sep = NULL, eos = NULL) {
   # Determine system type
-  stype <- sys_type()
-
-  # Pass to appropriate handler function
-  if(stype == "Darwin") {
-    osx_write_clip(content)
-  } else if(stype == "Windows") {
-    win_write_clip(content)
-  } else if(stype == "Linux") {
-    linux_write_clip(content)
-  } else {
-    stop("System not recognized!")
-  }
+  sys.type <- sys_type()
+  # Initialise an empty list to pass options on to OS-specific functions
+  wc.opts <- list()
+  # If they are non-NULL, they will be stored in the list
+  wc.opts$sep <- sep
+  wc.opts$eos <- eos
+  
+  # Choose an operating system-specific function (stop with error if not recognized)
+  chosen_write_clip <- switch(sys.type,
+                          "Darwin" = osx_read_clip,
+                          "Linux" = linux_write_clip,
+                          "Windows" = win_write_clip,
+                          stop("System not recognized!")
+                         )
+  
+  # Supply the clipboard content to write and options list to this function
+  chosen_write_clip(content, wc.opts)
 }

--- a/R/flat_str.R
+++ b/R/flat_str.R
@@ -1,0 +1,8 @@
+# Helper function to flatten content into 1-tuple character vector (i.e. a string)
+flat_str <- function(content, sep) {
+  content <- as.character(content)
+  if (length(content) > 1) {
+    content <- paste0(content, collapse = sep)
+  }
+  return(content)
+}

--- a/R/linux_clipboard.R
+++ b/R/linux_clipboard.R
@@ -29,7 +29,7 @@ linux_read_clip <- function() {
 # Adapted from https://github.com/mrdwab/overflow-mrdwab/blob/master/R/writeClip.R
 #
 # Targets "primary" and "clipboard" clipboards if using xclip, see: http://unix.stackexchange.com/a/69134/89254
-linux_write_clip <- function(content) {
+linux_write_clip <- function(content, wc.opts) {
   if (Sys.which("xclip") != "") {
     con <- pipe("xclip -i -sel p -f | xclip -i -sel c", "w")
   } else if (Sys.which("xsel") != "") {
@@ -37,7 +37,17 @@ linux_write_clip <- function(content) {
   } else {
     notify_no_cb()
   }
-  writeChar(content, con = con)
+  
+  # If no custom line separator has been specified, use Unix's default newline character: (\code{\n})
+  sep <- ifelse(is.null(wc.opts$sep), '\n', wc.opts$sep)
+  
+  # If no custom 'end of string' character is specified, then by default assign \code{eos = NULL}
+  # Text will be sent to the clipboard without a terminator character.
+  eos <- wc.opts$eos
+  # Note - works the same as ifelse(is.null,NULL,wc.opts$eos)
+  
+  content <- flat_str(content, sep)
+  writeChar(content, con = con, eos = eos)
   close(con)
   return(content)
 }

--- a/R/linux_clipboard.R
+++ b/R/linux_clipboard.R
@@ -25,15 +25,17 @@ linux_read_clip <- function() {
 #
 # Requires the Linux utility 'xclip' or 'xsel'. This function will stop with an error if neither is found.
 # Adapted from https://github.com/mrdwab/overflow-mrdwab/blob/master/R/writeClip.R
+#
+# Targets "primary" and "clipboard" clipboards if using xclip, see: http://unix.stackexchange.com/a/69134/89254
 linux_write_clip <- function(content) {
   if (Sys.which("xclip") != "") {
-    con <- pipe("xclip -i", "w")
+    con <- pipe("xclip -i -sel p -f | xclip -i -sel c", "w")
   } else if (Sys.which("xsel") != "") {
     con <- pipe("xsel -b", "w")
   } else {
     notify_no_cb()
   }
-  writeLines(content, con=con)
+  writeChar(content, con=con)
   close(con)
   return(content)
 }

--- a/R/linux_clipboard.R
+++ b/R/linux_clipboard.R
@@ -1,13 +1,14 @@
 # Function to stop the read/write and return an error of missing clipboard software.
 notify_no_cb <- function() {
-  stop("Clipboard on Linux requires 'xclip' or 'xsel'. Try using:\nsudo apt-get install xclip",
+  stop("Clipboard on Linux requires 'xclip' (recommended) or 'xsel'. Try using:\nsudo apt-get install xclip",
        call.=FALSE)
 }
 
 # Helper function to read from the Linux clipboard
 #
 # Requires the Linux utility 'xclip' or 'xsel'. This function will stop with an error if neither is found.
-# Adapted from https://github.com/mrdwab/overflow-mrdwab/blob/master/R/readClip.R
+# Adapted from: https://github.com/mrdwab/overflow-mrdwab/blob/master/R/readClip.R
+#          and: https://github.com/jennybc/reprex/blob/master/R/clipboard.R
 linux_read_clip <- function() {
   if (Sys.which("xclip") != "") {
     con <- pipe("xclip -o -selection clipboard")
@@ -16,7 +17,8 @@ linux_read_clip <- function() {
   } else {
     notify_no_cb()
   }
-  content <- readLines(con)
+  content <- scan(con, what = character(), sep = "\n",
+                  blank.lines.skip = FALSE, quiet = TRUE) 
   close(con)
   return(content)
 }

--- a/R/linux_clipboard.R
+++ b/R/linux_clipboard.R
@@ -37,7 +37,7 @@ linux_write_clip <- function(content) {
   } else {
     notify_no_cb()
   }
-  writeChar(content, con=con)
+  writeChar(content, con = con)
   close(con)
   return(content)
 }

--- a/R/osx_clipboard.R
+++ b/R/osx_clipboard.R
@@ -10,9 +10,19 @@ osx_read_clip <- function() {
 
 # Helper function to write to the OS X clipboard
 # Adapted from https://github.com/jennybc/reprex/blob/master/R/clipboard.R
-osx_write_clip <- function(content) {
+osx_write_clip <- function(content, wc.opts) {
   con <- pipe("pbcopy")
-  writeChar(content, con = con)
+  
+  # If no custom line separator has been specified, use Unix's default newline character: (\code{\n})
+  sep <- ifelse(is.null(wc.opts$sep), '\n', wc.opts$sep)
+  
+  # If no custom 'end of string' character is specified, then by default assign \code{eos = NULL},
+  # thus sending text to the clipboard without a terminator character.
+  eos <- wc.opts$eos
+  # Note - works the same as ifelse(is.null,NULL,wc.opts$eos)
+  
+  content <- flat_str(content, sep)
+  writeChar(content, con = con, eos = eos)
   close(con)
   return(content)
 }

--- a/R/osx_clipboard.R
+++ b/R/osx_clipboard.R
@@ -12,7 +12,7 @@ osx_read_clip <- function() {
 # Adapted from https://github.com/jennybc/reprex/blob/master/R/clipboard.R
 osx_write_clip <- function(content) {
   con <- pipe("pbcopy")
-  cat(content, file = con, sep = "\n")
+  writeChar(content, con = con)
   close(con)
   return(content)
 }

--- a/R/win_clipboard.R
+++ b/R/win_clipboard.R
@@ -4,7 +4,14 @@ win_read_clip <- function() {
 }
 
 # Helper function to write to the Windows clipboard
-win_write_clip <- function(content) {
+win_write_clip <- function(content, wc.opts) {
+
+  # If no custom line separator has been specified, use Linux's default newline character: (\code{\r\n})
+  sep <- ifelse(is.null(wc.opts$sep), '\r\n', wc.opts$sep)
+  
+  # Note - doesn't appear to be a way to supply eos to writeClipboard
+  
+  content <- flat_str(content, sep)
   writeClipboard(content, format = 1)
   return(content)
 }


### PR DESCRIPTION
Documentation, a `flat_str` function added, and a clear framework now for anyone wanting to pass in more awkward types to the clipboard, consistently, across different operating systems.
