### PR TITLE
clipr_available() preserves existing clipboard; fixes #17

### DIFF
--- a/R/sys_type.R
+++ b/R/sys_type.R
@@ -21,8 +21,17 @@ sys_type <- function() {
 #'
 #' @export
 clipr_available <- function() {
-  suppressWarnings({
-    !(inherits(try(write_clip("a"), silent = TRUE), "try-error") ||
-        inherits(try(read_clip(), silent = TRUE), "try-error"))
-  })
+  suppressWarnings(
+    read_attempt <- try(read_clip(), silent = TRUE)
+  )
+  if (inherits(read_attempt, "try-error")) {
+    return(FALSE)
+  }
+  suppressWarnings(
+    write_attempt <- try(write_clip(read_attempt), silent = TRUE)
+  )
+  if (inherits(write_attempt, "try-error")) {
+    return(FALSE)
+  }
+  TRUE
 }

--- a/tests/testthat/test_render.R
+++ b/tests/testthat/test_render.R
@@ -17,6 +17,13 @@ test_that("Unavailable clipboard throws warning", {
   }
 })
 
+test_that("clipr_available() does not overwrite existing contents", {
+  skip_if_not(clipr_available(), skip_msg)
+  write_clip("z")
+  clipr_available()
+  expect_equal(read_clip(), "z")
+})
+
 test_that("Render character vectors", {
   skip_if_not(clipr_available(), skip_msg)
 


### PR DESCRIPTION
In the process of fixing this, I also made things more verbose. If you see a nice way to make it shorter, I'd be happy to. The point here is to leave existing clipboard contents unharmed, when it exists and read/write is working.