### PR TITLE
Fixed clipboard handling on Linux.

### DIFF
--- a/R/linux_clipboard.R
+++ b/R/linux_clipboard.R
@@ -1,14 +1,17 @@
 # Determine if a given utility is installed AND accessible
-has_util <- function(util_name, util_test) {
-  if (nzchar(Sys.which(util_name))) {
+# Takes a character vector whose first element is the name of the
+# utility executable and whose subsequent elements are command-line
+# arguments to the utility for the test run.
+has_util <- function(util_test) {
+  if (nzchar(Sys.which(util_test[1]))) {
     # If utility is accessible, check that DISPLAY can be opened.
-    try_res <- tryCatch(system2(util_test, stdout = TRUE, stderr = TRUE),
+    try_res <- tryCatch(system2(util_test[1], util_test[-1], stdout = TRUE, stderr = TRUE),
                         error = function(c) FALSE,
                         warning = function(c) FALSE)
 
     # In the case of an error/warning on trying the function, then the util is
     # not available
-    if (try_res == FALSE) {
+    if (identical(try_res, FALSE)) {
       FALSE
     } else {
       TRUE
@@ -19,10 +22,10 @@ has_util <- function(util_name, util_test) {
 }
 
 # Determine if system has 'xclip' installed AND it's accessible
-has_xclip <- function() has_util("xclip", "xclip -o -selection clipboard")
+has_xclip <- function() has_util(c("xclip", "-o", "-selection", "clipboard"))
 
 # Determine if system has 'xsel' installed
-has_xsel <- function() has_util("xsel", "xsel --clipboard")
+has_xsel <- function() has_util(c("xsel", "--clipboard"))
 
 # Stop read/write and return an error of missing clipboard software.
 notify_no_cb <- function() {


### PR DESCRIPTION
Currently, has_util() calls system2() incorrectly, with the full command line as the first argument rather than arguments being a separate character vector, causing has_util() to always report a failure. This branch implements the following:
* Arguments to system2() in has_util() are now passed correctly.
* has_util() now takes just one argument: a character vector whose first element is the utility executable and whose subsequent elements are command-line arguments to the utility for the test run.
* has_xsel() and has_xclip() have been adjusted accordingly.