### PR TITLE
xclip has moved from R-Froge to Github

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Simple utility functions to read from and write to the Windows,
     OS X, and X11 clipboards.
 Imports:
     utils
-SystemRequirements: xclip (http://sourceforge.net/projects/xclip/) or xsel
+SystemRequirements: xclip (https://github.com/astrand/xclip) or xsel
     (http://www.vergenet.net/~conrad/software/xsel/) for accessing the X11
     clipboard
 License: GPL-3


### PR DESCRIPTION
I noticed that the repo has moved.

It is advertised on the old url: https://sourceforge.net/projects/xclip/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mdlincoln/clipr/25)
<!-- Reviewable:end -->
