### PR TITLE
Fixes for usage with xsel

### DIFF
--- a/R/linux_clipboard.R
+++ b/R/linux_clipboard.R
@@ -17,7 +17,7 @@ has_util <- function(util_test) {
       TRUE
     }
   } else {
-    notify_no_cb()
+    FALSE
   }
 }
 

--- a/R/linux_clipboard.R
+++ b/R/linux_clipboard.R
@@ -70,7 +70,7 @@ X11_write_clip <- function(content, object_type, breaks, eos, return_new, ...) {
   if (has_xclip()) {
     con <- pipe("xclip -i -sel p -f | xclip -i -sel c", "w")
   } else if (has_xsel()) {
-    con <- pipe("xsel -b", "w")
+    con <- pipe("xsel -b -i", "w")
   } else {
     notify_no_cb()
   }


### PR DESCRIPTION
Fixes to address #24 

Issue 1 was the premature error firing off of the no display error after `xclip` was not found. `xsel` was never getting a look in.

After that was resolved, `xsel` was breaking many tests due to outputting the contents of the clipboard when creating the connection with `pipe()`. With the `-i` option it seems not to do that. Not that the documentation is clear on why.