### PR TITLE
Require testthat >= 2.0.0.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ License: GPL-3
 LazyData: TRUE
 Suggests:
     rstudioapi (>= 0.5),
-    testthat,
+    testthat (>= 2.0.0),
     covr
 URL: https://github.com/mdlincoln/clipr
 BugReports: https://github.com/mdlincoln/clipr/issues


### PR DESCRIPTION
The setup feature was only added in this version.

It took me a long time to figure out why tests were not working on Fedora 27, which as it turns out, is still on testthat <2.0.0.